### PR TITLE
Warning: Undefined array key "rol"

### DIFF
--- a/views/director/pages/home.php
+++ b/views/director/pages/home.php
@@ -2,7 +2,7 @@
 
 session_start();
 
-if (!isset($_SESSION['user_id']) && $_SESSION['rol'] != 'Director') {
+if (!isset($_SESSION['user_id']) || ($_SESSION['user_id'] && $_SESSION['rol'] != 'Director')) {
 	header('Location: /');
 	exit();
 }


### PR DESCRIPTION
Undefined array key "rol": This warning occurs because $_SESSION['rol'] is accessed without first checking if $_SESSION['user_id'] is set. Ensure that $_SESSION['user_id'] is set before checking $_SESSION['rol'].
Cannot modify header information - headers already sent: This warning occurs because some output (HTML, whitespace, or other content) has been sent before the header() function is called. Make sure that no output is sent before calling header().

```php
<?php
// Start the session
session_start();

// Check if user_id is not set or if user is not a Director
if (!isset($_SESSION['user_id']) || ($_SESSION['user_id'] && $_SESSION['rol'] != 'Director')) {
    // Redirect to the home page
    header('Location: /');
    exit(); // Make sure to stop execution after redirecting
}
?>

<!-- Your HTML code for the Director's home page goes here -->
```

In this code:

I started the session at the beginning.
I checked if $_SESSION['user_id'] is not set or if the user role is not 'Director'.
I used the logical OR (||) operator instead of just && to check if either condition is true.
I redirected the user to the home page (/) if the conditions are not met.
I placed the HTML code for the Director's home page after the PHP logic to ensure that no output is sent before the header() function is called.